### PR TITLE
fixed unbounded frame timer

### DIFF
--- a/src/scenes/aaronMarcusHieroglyphB/aaronMarcusHieroglyphB.cpp
+++ b/src/scenes/aaronMarcusHieroglyphB/aaronMarcusHieroglyphB.cpp
@@ -67,7 +67,15 @@ void aaronMarcusHieroglyphB::update(){
 
 	//move all the lines based on their speeds
 	//using time-based animation
+	float lineWidth = dimensions.width - border * 2;
+	float maxFrameSec = lineWidth;
+	if (lineSpeedMin > 0){
+		maxFrameSec /= lineSpeedMin;
+	}
 	uint64_t frameMicros = ofGetSystemTimeMicros() - lastFrameMicros;
+	if (frameMicros > maxFrameSec * 1000000){
+		frameMicros = maxFrameSec * 1000000;
+	}
 	lastFrameMicros = ofGetSystemTimeMicros();
 	for(int i = 0; i < lines.size(); i++){
 		Line& line = lines[i];


### PR DESCRIPTION
turns out I didn't fix the bug in the Hieroglyph series before, but I swear I did now.

the frame timer was unbounded, so that meant if you didn't look at this piece for a while the "frame delay" would increase, and since the animations were time-based, the lines would move so far off screen that it would take a reeeeealy long time for the glyphs to populate back on-screen.

now at least they don't get too far away, so glyphs should start re-populating on screen (albeit from the right) quickly.
