### PR TITLE
Add new OSC messages for parameter changes and simulated typing events

### DIFF
--- a/src/scenes/sceneManager.h
+++ b/src/scenes/sceneManager.h
@@ -67,6 +67,7 @@ public:
     
 #ifdef USE_EXTERNAL_SOUNDS
     ofxOscSender oscSender;
+    ofxOscMessage oscMessage;
 #endif
     
 


### PR DESCRIPTION
Exposes all parameter changes as OSC messages.  

Examples:

```
/d4n/sceneStart
/d4n/keyPressed param-value
/d4n/param/id-of-param/value param-name param-value
/d4n/param/id-of-param/energy param-name param-energy
```
